### PR TITLE
Remove unneeded import and reorder fonts

### DIFF
--- a/assets/css/material.min.css
+++ b/assets/css/material.min.css
@@ -3,13 +3,12 @@
   Licensed under the MIT license
  */
 
-@import url("https://fonts.googleapis.com/icon?family=Material+Icons");
 @import url("https://fonts.googleapis.com/icon?family=Material+Icons|Roboto:300,400,500");
 
 body {
 
   margin: 0;
-  font-family: "Roboto", Arial, Helvetica, sans-serif;
+  font-family: "Roboto", "Helvetica", "Arial",sans-serif;
   font-weight: normal;
   background-color: #fff;
   overflow-x: hidden;


### PR DESCRIPTION
Remove the unneeded import so Material Design Icons isn't imported twice and reorder the font family to be the same as in the original MDL by Google.