### PR TITLE
Update iframe information

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,6 @@
       <a href="icons.html" class="waves-effect waves-light-blue"><span class="sidenav-icon"><i class="material-icons">extension</i></span><span>Icons</span></a>
       <a href="loaders.html" class="waves-effect waves-light-blue"><span class="sidenav-icon"><i class="material-icons">cached</i></span><span>Loaders</span></a>
       <a href="cards.html" class="waves-effect waves-light-blue"><span class="sidenav-icon"><i class="material-icons">check_box_outline_blank</i></span><span>Cards</span></a>
-
     </div>
 
     <div id="main" class="main">
@@ -69,8 +68,8 @@
       <div class="video-presentation">
 
         <div class="youtube-video">
-
-          <iframe src="https://www.youtube.com/embed/NPjzUyax4tw" allowfullscreen></iframe>
+          
+          <iframe src="https://www.youtube-nocookie.com/embed/NPjzUyax4tw?modestbranding=1&rel=0" frameborder="0" allowfullscreen></iframe>
 
         </div>
 


### PR DESCRIPTION
The following changes were made to the YouTube iframe on the main page:
- YouTube won't start collecting information about the user before the video has even loaded.
- The YouTube logo in the controls bar is moved to a more subtle location
- The related videos at the end of the video are removed from taking up the whole video space